### PR TITLE
Add 2FA authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,17 @@
 import * as prompt from '@inquirer/prompts';
-import {encryptPassword, fetchVerification, login, TwoFactorRequired, VerificationData, verify2FA} from "./instagram";
+import {
+    encryptPassword,
+    fetchVerification,
+    login,
+    TwoFactorInformation,
+    TwoFactorRequired,
+    VerificationData,
+    verify2FA
+} from "./instagram";
 import {ExitPromptError} from "@inquirer/prompts";
 
 
-async function authenticate() {
+async function authenticate(): Promise<string> {
     const verification = await fetchVerification()
 
     while (true) {
@@ -20,17 +28,20 @@ async function authenticate() {
                 continue
             }
 
-            return await twoFactor({user, verification})
+            return await twoFactor({info: (e as TwoFactorRequired).info, verification})
         }
     }
 }
 
-async function twoFactor({verification, user}: { verification: VerificationData, user: string }) {
+async function twoFactor({verification, info}: {
+    verification: VerificationData,
+    info: TwoFactorInformation
+}): Promise<string> {
     while (true) {
         const code = await prompt.input({message: "Two factor authentication code: "})
 
         try {
-            return await verify2FA({verification, code, user})
+            return await verify2FA({verification, code, info})
         } catch (e) {
             console.error(e.message)
         }

--- a/src/instagram.ts
+++ b/src/instagram.ts
@@ -5,9 +5,18 @@ const crypto = globalThis.crypto
 const encoder = new TextEncoder()
 
 export class TwoFactorRequired extends Error {
-    constructor() {
+    info: TwoFactorInformation
+
+    constructor(info: TwoFactorInformation) {
         super("Two factor authentication is enabled for this account.");
+        this.info = info
     }
+}
+
+export interface TwoFactorInformation {
+    identifier: string,
+    user: string,
+    device: string
 }
 
 export interface InstagramEncryptionKey {
@@ -100,6 +109,20 @@ export async function encryptPassword({time, password, key, providedKey}: {
     return {timestamp: parseInt(timeString, 10), cipher: btoa(converted.join(''))}
 }
 
+function getSessionId(response: Response): string {
+    const identifier = "sessionid="
+    const identify = (cookie: string) => cookie.startsWith(identifier)
+
+    return response.headers
+        .getSetCookie().find(identify)
+        .split(";").find(identify)
+        .substring(identifier.length)
+}
+
+function hasJsonBody(response: Response): boolean {
+    return response.headers.get("Content-Type").startsWith("application/json;")
+}
+
 export async function login({user, password, verification}: {
     user: string,
     password: EncryptedPassword,
@@ -122,14 +145,23 @@ export async function login({user, password, verification}: {
     })
 
     if (!response.ok) {
-        if (response.headers.get("Content-Type").startsWith("application/json;")) {
+        if (hasJsonBody(response)) {
             const data = await response.json() as {
                 message?: string,
-                two_factor_required?: boolean
+                two_factor_required?: boolean,
+                two_factor_info?: {
+                    username: string,
+                    two_factor_identifier: string,
+                    device_id: string
+                }
             }
 
             if (data.two_factor_required) {
-                throw new TwoFactorRequired()
+                throw new TwoFactorRequired({
+                    user: data.two_factor_info.username,
+                    identifier: data.two_factor_info.two_factor_identifier,
+                    device: data.two_factor_info.device_id
+                })
             }
 
             throw new Error(data.message ?? "Login attempted failed.")
@@ -142,15 +174,33 @@ export async function login({user, password, verification}: {
         throw new Error("Authentication failed.")
     }
 
-    const identifier = "sessionid="
-    const identify = (cookie: string) => cookie.startsWith(identifier)
-
-    return response.headers
-        .getSetCookie().find(identify)
-        .split(";").find(identify)
-        .substring(identifier.length)
+    return getSessionId(response)
 }
 
-export async function verify2FA({}: { user: string, verification: VerificationData, code: string }) {
-    throw Error("Not implemented.")
+export async function verify2FA({verification, info, code}: {
+    info: TwoFactorInformation,
+    verification: VerificationData,
+    code: string
+}): Promise<string> {
+    const body = new FormData()
+    body.set("username", info.user)
+    body.set("identifier", info.identifier)
+    body.set("verificationCode", code)
+
+    const response = await fetch("https://www.instagram.com/api/v1/web/accounts/login/ajax/two_factor/", {
+        method: "POST",
+        headers: {
+            "X-CSRFToken": verification.csrf,
+            "Sec-Fetch-Site": "same-origin",
+            "X-Mid": info.device,
+        },
+        body
+    })
+
+    if (!response.ok) {
+        const message = hasJsonBody(response) ? (await response.json()).message : await response.text()
+        throw Error(message ?? "Two factor authentication failed.")
+    }
+
+    return getSessionId(response)
 }

--- a/src/instagram.ts
+++ b/src/instagram.ts
@@ -150,3 +150,7 @@ export async function login({user, password, verification}: {
         .split(";").find(identify)
         .substring(identifier.length)
 }
+
+export async function verify2FA({}: { user: string, verification: VerificationData, code: string }) {
+    throw Error("Not implemented.")
+}


### PR DESCRIPTION
Allows you to sign in with a two factor authentication enabled Instagram account.

If multiple 2FA methods are setup up, you cannot request an different method than the default one chosen by Instagram with this tool. For example, you cannot request a text message when using an authentication app.

**Before accepting this pull request, #1 should be squashed into `main` and this branch rebased on the updated `main`-branch.**