### PR TITLE
Add fetching task queue

### DIFF
--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -16,7 +16,7 @@ export async function settleGraph(graph: UnsettledUserGraph) {
                 image: await user.profile.image
                     .then((image: Blob | null) => {
                         if (!image) {
-                            console.error(`Failed to download profile picture. (User: ${user.profile.username})`)
+                            console.error(`Failed to download profile picture. (${user.profile.username})`)
                             return null;
                         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as prompt from '@inquirer/prompts';
 import {ExitPromptError} from '@inquirer/prompts';
-import {FollowerFetcherEvent, FollowerFetcherEventTypes, getFollowerGraph} from "./instagram/follower";
+import {FollowerFetcherEvent, FollowerFetcherEventTypes, fetchFollowerGraph} from "./instagram/follower";
 import SessionData from "./instagram/session-data";
 import {UnsettledUser, UnsettledUserGraph, UserGraph} from "./instagram/user";
 import {PathOrFileDescriptor, writeFileSync} from "node:fs";
@@ -139,7 +139,7 @@ try {
 
     const includeFollowing = await prompt.confirm({message: "Include following?", default: true})
 
-    const stream = getFollowerGraph({
+    const stream = fetchFollowerGraph({
         includeFollowing,
         root,
         session,

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,10 @@ try {
                 },
                 parallelTasks: 20,
                 delay: {
+                    images: {
+                        upper: 5000,
+                        lower: 500
+                    },
                     pages: {
                         upper: 40000,
                         lower: 20000

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,9 +97,9 @@ async function streamGraph(root: UnsettledUser, filename: string, stream: Readab
                 const users = value.added.users.length
 
                 console.log(
-                    `${time} Added ${followers > 0 ? followers : 'no'} follower${followers > 1 ? 's' : ''} to ${value.user.profile.username}. ` +
+                    `${time} Added ${followers > 0 ? followers : 'no'} follower${followers > 1 ? 's' : ''}. ` +
                     `Discovered ${users > 0 ? users : 'no'} new user${users > 1 ? 's' : ''}. ` +
-                    `Total user count: ${total}, completely queried users ${value.added.progress.done}.`
+                    `Total user count: ${total}, completely queried users ${value.added.progress.done}. ${identifier}`
                 )
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ try {
     await Promise.all([
         fileWriters.then(() => {
             console.info(
-                "The may process still needs to wait on the rate limiting timeouts to exit cleanly. " +
+                "The process may still needs to wait on the rate limiting timeouts to exit cleanly. " +
                 "Killing it should not cause any data lose."
             )
         }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,8 @@ try {
     })
 
     const {graph: unsettledGraph, cancellation} = await streamGraph(root, filename, stream)
+
+    console.log('Waiting for profile pictures to be downloaded.')
     const graph = await settleGraph(unsettledGraph)
 
     const fileWriters = Promise.allSettled([

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ async function streamGraph(root: UnsettledUser, filename: string, stream: Readab
 
             graph = value.graph
 
-            const identifier = `(User: ${value.user.profile.username})`
+            const identifier = `(${value.user.profile.username})`
             const time = `[${new Date().toISOString()}]`
 
             if (value.type === FollowerFetcherEventTypes.DEPTH_LIMIT_FOLLOWER) {
@@ -93,11 +93,13 @@ async function streamGraph(root: UnsettledUser, filename: string, stream: Readab
                 await updatesSaveFiles(value.graph)
             } else if (value.type === FollowerFetcherEventTypes.UPDATE) {
                 const total = Object.entries(value.graph).length
-                const followers = value.added.followers.length;
+                const followers = value.added.followers.ids.length;
                 const users = value.added.users.length
+                const targetUsername = value.added.followers.target.profile.username;
+
 
                 console.log(
-                    `${time} Added ${followers > 0 ? followers : 'no'} follower${followers > 1 ? 's' : ''}. ` +
+                    `${time} Added ${followers > 0 ? followers : 'no'} follower${followers > 1 ? 's' : ''} to ${targetUsername}. ` +
                     `Discovered ${users > 0 ? users : 'no'} new user${users > 1 ? 's' : ''}. ` +
                     `Total user count: ${total}, completely queried users ${value.added.progress.done}. ${identifier}`
                 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,16 +79,17 @@ async function streamGraph(root: UnsettledUser, filename: string, stream: Readab
             graph = value.graph
 
             const identifier = `(User: ${value.user.profile.username})`
+            const time = `[${new Date().toISOString()}]`
 
             if (value.type === FollowerFetcherEventTypes.DEPTH_LIMIT_FOLLOWER) {
-                console.log(`Reached the maximum amount of followers to include. Currently included are ${value.amount}. ${identifier}`)
+                console.log(`${time} Reached the maximum amount of followers to include. Currently included are ${value.amount}. ${identifier}`)
             } else if (value.type === FollowerFetcherEventTypes.DEPTH_LIMIT_FOLLOWING) {
-                console.log(`Reached the maximum amount of followed users to include. Currently included are ${value.amount}. ${identifier}`)
+                console.log(`${time} Reached the maximum amount of followed users to include. Currently included are ${value.amount}. ${identifier}`)
             } else if (value.type === FollowerFetcherEventTypes.RATE_LIMIT_BATCH) {
-                console.log(`Reached follower batch limit. Resuming after ${value.delay} milliseconds. ${identifier}`)
+                console.log(`${time} Reached follower batch limit. Resuming after ${value.delay} milliseconds. ${identifier}`)
                 await updatesSaveFiles(value.graph)
             } else if (value.type === FollowerFetcherEventTypes.RATE_LIMIT_DAILY) {
-                console.log(`Reached follower daily limit. Resuming after ${value.delay} milliseconds. ${identifier}`)
+                console.log(`${time} Reached follower daily limit. Resuming after ${value.delay} milliseconds. ${identifier}`)
                 await updatesSaveFiles(value.graph)
             } else if (value.type === FollowerFetcherEventTypes.UPDATE) {
                 const total = Object.entries(value.graph).length
@@ -96,7 +97,7 @@ async function streamGraph(root: UnsettledUser, filename: string, stream: Readab
                 const users = value.added.users.length
 
                 console.log(
-                    `Added ${followers > 0 ? followers : 'no'} follower${followers > 1 ? 's' : ''} to ${value.user.profile.username}. ` +
+                    `${time} Added ${followers > 0 ? followers : 'no'} follower${followers > 1 ? 's' : ''} to ${value.user.profile.username}. ` +
                     `Discovered ${users > 0 ? users : 'no'} new user${users > 1 ? 's' : ''}. ` +
                     `Total user count: ${total}, completely queried users ${value.added.progress.done}.`
                 )

--- a/src/instagram/follower.ts
+++ b/src/instagram/follower.ts
@@ -385,10 +385,7 @@ async function fetchFollowers({session, user, page, direction, limits}: {
                 profile: {
                     username: user.username,
                     name: user.full_name,
-                    image: randomDelay({
-                        lower: 0,
-                        upper: limits.rate.delay.pages.upper
-                    }).delay.then(() => downloadProfilePicture(user.profile_pic_url))
+                    image: randomDelay(limits.rate.delay.images).delay.then(() => downloadProfilePicture(user.profile_pic_url))
                 },
                 public: !user.is_private,
                 private: user.is_private && id != session.user.id

--- a/src/instagram/follower.ts
+++ b/src/instagram/follower.ts
@@ -155,7 +155,7 @@ function addFollowingToGraph({graph, following, target}: {
     }))
 }
 
-export function getFollowerGraph({root, session, limits, includeFollowing}: {
+export function fetchFollowerGraph({root, session, limits, includeFollowing}: {
     root: UnsettledUser,
     session: SessionData,
     includeFollowing: boolean,

--- a/src/instagram/follower.ts
+++ b/src/instagram/follower.ts
@@ -256,7 +256,7 @@ async function createFollowerGraph({controller, limits, graph, session, includeF
                 return tasks
             }, [])
 
-        if (taskQueue.length < 1 || graph.canceled) break;  // no open task, skip remaining generations
+        if (taskQueue.length < 1) break;  // no open task, skip remaining generations
 
         // Users per response: followers = 25, following = 200
         const maxParallel = Math.min(
@@ -265,7 +265,7 @@ async function createFollowerGraph({controller, limits, graph, session, includeF
         )
 
         const runners = new Array(maxParallel).fill(async () => {
-            while (taskQueue.length > 0) {
+            while (taskQueue.length > 0 && !graph.canceled) {
                 const task = taskQueue.pop()
                 if (!task.job) {
                     done.add(task.user.id)

--- a/src/instagram/follower.ts
+++ b/src/instagram/follower.ts
@@ -154,7 +154,6 @@ export function getFollowerGraph({root, session, limits, includeFollowing}: {
 
     return new ReadableStream<FollowerFetcherEvent>({
         start: async (controller: ReadableStreamDefaultController<FollowerFetcherEvent>) => {
-
             if (root.private) {
                 controller.enqueue({
                     type: FollowerFetcherEventTypes.UPDATE,

--- a/src/instagram/follower.ts
+++ b/src/instagram/follower.ts
@@ -264,7 +264,7 @@ async function createFollowerGraph({controller, limits, graph, session, includeF
             limits.rate.parallelTasks
         )
 
-        const runners = new Array(maxParallel).fill(async () => {
+        const runners = new Array(Math.max(maxParallel, 1)).fill(async () => {
             while (taskQueue.length > 0 && !graph.canceled) {
                 const task = taskQueue.pop()
                 if (!task.job) {

--- a/src/instagram/follower.ts
+++ b/src/instagram/follower.ts
@@ -71,7 +71,7 @@ async function rateLimiter({graph, user, phase, taskCount, limits, controller}: 
             })
 
             await delay.delay
-            return phase
+            return phaseProgression
         }
     }
 

--- a/src/instagram/follower.ts
+++ b/src/instagram/follower.ts
@@ -37,17 +37,14 @@ function randomDelay(limit: RandomDelayLimit) {
 }
 
 
-async function rateLimiter({graph, user, phase, taskCount, limits, controller}: {
+async function rateLimiter({graph, user, phase, limits, controller}: {
     graph: UnsettledUserGraph,
     user: UnsettledUser,
     phase: number,
-    taskCount: number
     limits: Limits,
     controller: ReadableStreamDefaultController<FollowerFetcherEvent>
 }) {
-    const phaseProgression = Math.floor(
-        Object.entries(graph).length / (limits.rate.batch.size - taskCount * 25)
-    )
+    const phaseProgression = Math.floor(Object.entries(graph).length / limits.rate.batch.size)
 
     if (phase < phaseProgression) {
         if (phaseProgression > limits.rate.batch.count) {
@@ -277,8 +274,7 @@ async function createFollowerGraph({controller, limits, graph, session, includeF
                     user: task.user,
                     phase,
                     limits,
-                    controller,
-                    taskCount: taskQueue.length
+                    controller
                 })
 
                 const next = await taskRunner(graph, task, limits)

--- a/src/instagram/limits.ts
+++ b/src/instagram/limits.ts
@@ -15,6 +15,7 @@ export interface Limits {
         }
         parallelTasks: number
         delay: {
+            images: RandomDelayLimit,
             daily: RandomDelayLimit,
             batches: RandomDelayLimit,
             pages: RandomDelayLimit

--- a/src/instagram/user.ts
+++ b/src/instagram/user.ts
@@ -8,6 +8,7 @@ export interface User {
         image: string
     },
     followerIds?: number[],
+    followingCount?: number
     private?: boolean,
     public: boolean,
     personal?: boolean
@@ -21,6 +22,7 @@ export interface UnsettledUser {
         image: Promise<Blob> | null,
     }
     followerIds?: number[],
+    followingCount?: number
     private?: boolean,
     public: boolean,
     personal?: boolean

--- a/src/visualization/index.ts
+++ b/src/visualization/index.ts
@@ -25,7 +25,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     toolbar.addEventListener("remove-highlighting", () => visualization.removeHighlights());
     toolbar.addEventListener("reset-positioning", () => visualization.resetPositioning())
 
-    toolbar.addEventListener("search-user", function (event: CustomEvent) {
+    toolbar.addEventListener("search-user", async function (event: CustomEvent) {
         const matchingUser = users.find((user: User) => user.profile.username === event.detail);
 
         if (!matchingUser) return toolbar.setSearchError(`No user found with the exact username: ${event.detail}`)


### PR DESCRIPTION
Create tasks for fetching followers and following. Each page of the result creates a new task which gets added to the back of the queue. This results in a more breath-first approach, which should result in a more complete picture faster. It also makes failed results more meaningful.

In addition, this allows the process to be canceled while pages get retrieved.

The resulting code is cleaner IMO. 